### PR TITLE
Fixing PIs

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rm aleph*mods aleph*marc

--- a/eliminate_empty_eles.xsl
+++ b/eliminate_empty_eles.xsl
@@ -1,20 +1,15 @@
 <xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
 	       xmlns:m="http://www.loc.gov/mods/v3" 
                version="2.0">
+  <xsl:strip-space elements="*"/>
 
-
- <xsl:template match="node()">
-   <xsl:if test="node()|@*">
-     <xsl:copy>
-      <xsl:apply-templates select="node()|@*"/>
-     </xsl:copy>
-   </xsl:if>
+ <xsl:template match="node()|@*">
+   <xsl:copy>
+     <xsl:apply-templates select="node()|@*"/>
+   </xsl:copy>
  </xsl:template>
 
- <xsl:template match="@*">
-    <xsl:copy>
-      <xsl:apply-templates select="."/>
-    </xsl:copy>
- </xsl:template>
+ <xsl:template match=
+	       "*[not(@*|*|comment()|processing-instruction()) and normalize-space()='']"/>
 
 </xsl:transform>

--- a/eliminate_empty_eles.xsl
+++ b/eliminate_empty_eles.xsl
@@ -1,0 +1,20 @@
+<xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+	       xmlns:m="http://www.loc.gov/mods/v3" 
+               version="2.0">
+
+
+ <xsl:template match="node()">
+   <xsl:if test="node()|@*">
+     <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+     </xsl:copy>
+   </xsl:if>
+ </xsl:template>
+
+ <xsl:template match="@*">
+    <xsl:copy>
+      <xsl:apply-templates select="."/>
+    </xsl:copy>
+ </xsl:template>
+
+</xsl:transform>

--- a/eliminate_empty_eles.xsl
+++ b/eliminate_empty_eles.xsl
@@ -1,15 +1,17 @@
 <xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
 	       xmlns:m="http://www.loc.gov/mods/v3" 
                version="2.0">
+ 
   <xsl:strip-space elements="*"/>
+  <xsl:output indent="yes"/>
 
- <xsl:template match="node()|@*">
-   <xsl:copy>
-     <xsl:apply-templates select="node()|@*"/>
-   </xsl:copy>
- </xsl:template>
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
 
- <xsl:template match=
-	       "*[not(@*|*|comment()|processing-instruction()) and normalize-space()='']"/>
+  <xsl:template match=
+		"*[not(@*|*|comment()|processing-instruction()) and normalize-space()='']"/>
 
 </xsl:transform>

--- a/oaimarc2slimmarc.xsl
+++ b/oaimarc2slimmarc.xsl
@@ -452,9 +452,9 @@
     <xsl:if test="subfield[@label = 'a'] |
 		  subfield[@label = 'h']">
 
-      <xsl:processing-instruction name="family"><xsl:apply-templates select="subfield[@label = 'a']/string()"/></xsl:processing-instruction>
+      <xsl:processing-instruction name="family"><xsl:value-of select="subfield[@label = 'a']"/></xsl:processing-instruction>
       
-      <xsl:processing-instruction name="given"><xsl:apply-templates select="subfield[@label = 'h']/string()"/></xsl:processing-instruction>
+      <xsl:processing-instruction name="given"><xsl:value-of select="subfield[@label = 'h']"/></xsl:processing-instruction>
 
       <xsl:element name="marc:subfield">
 	<xsl:attribute name="code">a</xsl:attribute>

--- a/oaimarc2slimmarc.xsl
+++ b/oaimarc2slimmarc.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<xsl:transform version="2.0"
+<xsl:transform version="3.0"
 	       xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	       xmlns:marc="http://www.loc.gov/MARC21/slim"
 	       xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -452,9 +452,9 @@
     <xsl:if test="subfield[@label = 'a'] |
 		  subfield[@label = 'h']">
 
-      <xsl:processing-instruction name="family"><xsl:apply-templates select="subfield[@label = 'a']"/></xsl:processing-instruction>
+      <xsl:processing-instruction name="family"><xsl:apply-templates select="subfield[@label = 'a']/string()"/></xsl:processing-instruction>
       
-      <xsl:processing-instruction name="given"><xsl:apply-templates select="subfield[@label = 'h']"/></xsl:processing-instruction>
+      <xsl:processing-instruction name="given"><xsl:apply-templates select="subfield[@label = 'h']/string()"/></xsl:processing-instruction>
 
       <xsl:element name="marc:subfield">
 	<xsl:attribute name="code">a</xsl:attribute>

--- a/samples/aleph13.xml
+++ b/samples/aleph13.xml
@@ -1,0 +1,100 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<present>
+<record>
+<record_header>
+<set_entry>000000001</set_entry>
+</record_header>
+<doc_number>003431556</doc_number>
+<metadata>
+<oai_marc>
+<fixfield id="FMT">BK</fixfield>
+<fixfield id="LDR">00724name-22002175--450-</fixfield>
+<varfield id="001" i1="0" i2="0">
+<subfield label="a">x929169543</subfield>
+<subfield label="f">a</subfield>
+</varfield>
+<varfield id="004" i1="0" i2="0">
+<subfield label="r">n</subfield>
+<subfield label="a">e</subfield>
+</varfield>
+<varfield id="008" i1="0" i2="0">
+<subfield label="t">m</subfield>
+<subfield label="u">f</subfield>
+<subfield label="a">2012</subfield>
+<subfield label="b">dk</subfield>
+<subfield label="d">y</subfield>
+<subfield label="k">a</subfield>
+<subfield label="l">dan</subfield>
+<subfield label="n">b</subfield>
+<subfield label="x">06</subfield>
+<subfield label="v">5</subfield>
+</varfield>
+<varfield id="009" i1="0" i2="0">
+<subfield label="a">a</subfield>
+<subfield label="g">xe</subfield>
+</varfield>
+<varfield id="021" i1="0" i2="0">
+<subfield label="e">9788792875068</subfield>
+</varfield>
+<varfield id="032" i1="0" i2="0">
+<subfield label="a">DBF201206</subfield>
+</varfield>
+<varfield id="096" i1="0" i2="0">
+<subfield label="a"></subfield>
+</varfield>
+<varfield id="100" i1="0" i2="0">
+<subfield label="a">Vagt</subfield>
+<subfield label="h">Ingeborg</subfield>
+<subfield label="4">aut</subfield>
+</varfield>
+<varfield id="245" i1="0" i2="0">
+<subfield label="a">Der var engang en barndom</subfield>
+<subfield label="c">barndomserindringer</subfield>
+</varfield>
+<varfield id="260" i1="0" i2="0">
+<subfield label="b">&lt;&lt;Mellemgaard=Mellemgård&gt;&gt;</subfield>
+<subfield label="c">2012</subfield>
+</varfield>
+<varfield id="300" i1="0" i2="0">
+<subfield label="a">129 sider</subfield>
+</varfield>
+<varfield id="512" i1="0" i2="0">
+<subfield label="a">Downloades i EPUB-format</subfield>
+</varfield>
+<varfield id="512" i1="0" i2="0">
+<subfield label="a">Beskrivelsen baseret på det fysiske forlæg</subfield>
+</varfield>
+<varfield id="595" i1="0" i2="0">
+<subfield label="a">e-pligt</subfield>
+</varfield>
+<varfield id="652" i1="0" i2="0">
+<subfield label="m">99.4</subfield>
+<subfield label="a">Vagt</subfield>
+<subfield label="h">Ingeborg</subfield>
+</varfield>
+<varfield id="856" i1="0" i2="0">
+<subfield label="z">Adgangsmåde: Internet</subfield>
+<subfield label="u">http://www.mellemgaard.dk/product.asp?product=348</subfield>
+<subfield label="z">Adgang til køb ved udgivelsen</subfield>
+</varfield>
+<fixfield id="BAS">bcx</fixfield>
+<varfield id="CAT" i1=" " i2=" ">
+<subfield label="a">dig1206imp</subfield>
+<subfield label="b"></subfield>
+<subfield label="c">20170502</subfield>
+<subfield label="l">KGL02</subfield>
+<subfield label="h">1136</subfield>
+</varfield>
+<varfield id="UID" i1=" " i2=" ">
+<subfield label="a">x929169543bcx</subfield>
+</varfield>
+<varfield id="720" i1="0" i2="0">
+<subfield label="o">Camilla Faieq Jensen</subfield>
+<subfield label="4">edt</subfield>
+</varfield>
+</oai_marc>
+</metadata>
+</record>
+<session-id>D4UXXCKANL3F2UQSYAGXU1CEP8KFVPATB67GJ6MU4L4LAEK9AY</session-id>
+</present>
+ 

--- a/schemas.xml
+++ b/schemas.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <locatingRules xmlns="http://thaiopensource.com/ns/locating-rules/1.0">
+  <uri resource="valid_record.mods" uri="mods-3-7.rnc"/>
   <uri resource="aleph11.mods" uri="mods-3-7.rnc"/>
   <uri resource="MODS.xml" uri="mods-3-7.rnc"/>
 </locatingRules>

--- a/transform-test.sh
+++ b/transform-test.sh
@@ -8,6 +8,8 @@ for file in samples/*xml ; do
     saxonb-xslt -xsl:$OAIMARC2SLIMMARC -s:$file -o:`basename $file .xml`.marc
     xsltproc marcToMODS.xsl `basename $file .xml`.marc > `basename $file .xml`.mods
     xmllint --noout --schema mods-3-7.xsd `basename $file .xml`.mods
+    saxonb-xslt -xsl:eliminate_empty_eles.xsl `basename $file .xml`.mods > `basename $file .xml`_no_empty_eles.mods
+    xmllint --noout --schema mods-3-7.xsd `basename $file .xml`_no_empty_eles.mods
 
 done
 


### PR DESCRIPTION
fixing two bugs:

1. an earlier in the handling of processing instructions (PIs)
2. a new xsl removes empty nodes from the tree. solves problem with empty 

<originInfo> ... </originInfo>

See samples/aleph13.xml which triggers the creation of such an empty element. *NB* such elements can still arise if contained elements are removed

3. We also include a valid reference document valid_record.mods ;^)